### PR TITLE
Added 'utf8' and 'arr' to type exports

### DIFF
--- a/src/bson.erl
+++ b/src/bson.erl
@@ -3,6 +3,7 @@
 
 -export_type ([maybe/1]).
 -export_type ([document/0, label/0, value/0]).
+-export_type ([arr/0]).
 -export_type ([bin/0, bfunction/0, uuid/0, md5/0, userdefined/0]).
 -export_type ([mongostamp/0, minmaxkey/0]).
 -export_type ([utf8/0, regex/0, unixtime/0]).


### PR DESCRIPTION
`bson` didn't export some of the types, used in `mongodb-erlang`, which caused a `dialyzer` error. 
