### PR TITLE
Support key as integer for the maps put.

### DIFF
--- a/src/bson_binary.erl
+++ b/src/bson_binary.erl
@@ -44,6 +44,8 @@ get_map(<<?get_int32(N), Bin/binary>>) ->
 %% @private
 put_field_accum(Label, Value, Bin) when is_atom(Label) ->
   <<Bin/binary, (put_field(atom_to_binary(Label, utf8), Value))/binary>>;
+put_field_accum(Label, Value, Bin) when is_integer(Label) ->
+  <<Bin/binary, (put_field(integer_to_binary(Label), Value))/binary>>;
 put_field_accum(Label, Value, Bin) when is_binary(Label) ->
   <<Bin/binary, (put_field(Label, Value))/binary>>.
 

--- a/test/bson_tests.erl
+++ b/test/bson_tests.erl
@@ -104,10 +104,10 @@ utf8_test() ->
   ?assertEqual(<<"test">>, bson:utf8("test")).
 
 maps_put_test() ->
-  SimpleMap = #{<<"map">> => true, <<"simple">> => <<"very">>, atom => key, array => [1, 2, 3, 4]},
+  SimpleMap = #{<<"map">> => true, <<"simple">> => <<"very">>, atom => key, array => [1, 2, 3, 4], 1024 => <<"integer value">>},
   Encoded1 = bson_binary:put_document(SimpleMap),
   {Decoded1, <<>>} = bson_binary:get_document(Encoded1),
-  ?assertEqual({<<"array">>, [1, 2, 3, 4], <<"atom">>, key, <<"map">>, true, <<"simple">>, <<"very">>}, Decoded1),
+  ?assertEqual({<<"1024">>, <<"integer value">>, <<"array">>, [1, 2, 3, 4], <<"atom">>, key, <<"map">>, true, <<"simple">>, <<"very">>}, Decoded1),
   MapWithMap = #{<<"map">> => true, <<"simple">> => <<"not">>, <<"why">> => #{<<"because">> => <<"with map">>, ok => true}},
   Encoded2 = bson_binary:put_document(MapWithMap),
   {Decoded2, <<>>} = bson_binary:get_document(Encoded2),


### PR DESCRIPTION
Support key as integer for the maps put. Add test case at `bson_tests:maps_put_test/0`.