### PR TITLE
bson_binary: fix for wrong maps usage

### DIFF
--- a/src/bson_binary.erl
+++ b/src/bson_binary.erl
@@ -52,7 +52,7 @@ get_fields(<<>>, Acc) when is_map(Acc) -> Acc;
 get_fields(<<>>, Acc) -> lists:reverse(Acc);
 get_fields(Bin, Acc) when is_map(Acc) ->
   {Name, Value, Bin1} = get_field(Bin, map),
-  get_fields(Bin1, Acc#{Name => Value});
+  get_fields(Bin1, maps:put(Name, Value, Acc));
 get_fields(Bin, Acc) ->
   {Name, Value, Bin1} = get_field(Bin, normal),
   get_fields(Bin1, [Value, Name | Acc]).


### PR DESCRIPTION
It didn't compile. I guess that that line just needs to update the Acc which is a map. This does it.