### PR TITLE
Add support for encoding '+-infinity'

### DIFF
--- a/test/bson_tests.erl
+++ b/test/bson_tests.erl
@@ -146,3 +146,18 @@ maps_flattering_test() ->
       <<"email">> => <<"test@test.su">>
     },
   ?assertEqual(FlattenMap, Result).
+
+infinity_test() ->
+  Encoded = <<16#2b, 16#00, 16#00, 16#00, 16#01, 16#2b, 16#69, 16#6e, 16#66,
+              16#69, 16#6e, 16#69, 16#74, 16#79, 16#00, 16#00, 16#00, 16#00,
+              16#00, 16#00, 16#00, 16#f0, 16#7f, 16#01, 16#2d, 16#69, 16#6e,
+              16#66, 16#69, 16#6e, 16#69, 16#74, 16#79, 16#00, 16#00, 16#00,
+              16#00, 16#00, 16#00, 16#00, 16#f0, 16#ff, 16#00>>,
+
+  ?assertEqual(
+    {{<<"+infinity">>, '+infinity', <<"-infinity">>, '-infinity'}, <<>>},
+    bson_binary:get_document(Encoded)),
+
+  Doc = #{<<"+infinity">> => '+infinity', <<"-infinity">> => '-infinity'},
+  Encoded2 = bson_binary:put_document(Doc),
+  ?assertEqual(Encoded, Encoded2).


### PR DESCRIPTION
Javascript (and therefore MongoDB) has a concept of +-Infinity. This works in other clients bson parsers (at least Haskells) but fails in Erlang (trace below) 

Erlang can't process the float that is equivialant of Javascripts Infinity,
`Number.(POSITIVE,NEGATIVE)_INFINITY`, which is the max- and
minimum floating point.

This patch allows the BSON parser to atleast return something somewhat appropriate.

```elixir
# try to query back
:poolboy.transaction :mongodb, fn(conn) -> :mongo.find_one(conn, :test, %{}) end
** (exit) exited in: :gen_server.call(#PID<0.3001.0>, {:query, false, false, false, false, :test, 0, -1, %{}, []}, :infinity)
    ** (EXIT) an exception was raised:
        ** (MatchError) no match of right hand side value: <<0, 0, 0, 0, 0, 0, 240, 127>>
            (bson) src/bson_binary.erl:87: :bson_binary.get_field/4
            (bson) src/bson_binary.erl:144: :bson_binary.get_field/2
            (bson) src/bson_binary.erl:54: :bson_binary.get_fields/2
            (bson) src/bson_binary.erl:40: :bson_binary.get_map/1
            (mongodb) src/core/mongo_protocol.erl:111: :mongo_protocol.get_docs/3
            (mongodb) src/core/mongo_protocol.erl:92: :mongo_protocol.get_reply/1
            (mongodb) src/connection/mc_worker_logic.erl:68: :mc_worker_logic.decode_responses/2
            (mongodb) src/connection/mc_worker.erl:102: :mc_worker.handle_info/2

```

----

## Note on comparison

Since there is no concept of a minimum value both are atoms.  This means
you can compare any number to '+infinity" and it will always be larger;
however '-infinity' will also be larger than any number... This means no `+infinity > 0 > -infinity`.