### PR TITLE
bug when 'avgDistance' value is NaN

### DIFF
--- a/src/bson_binary.erl
+++ b/src/bson_binary.erl
@@ -84,8 +84,13 @@ put_field(N, V) -> erlang:error(bad_bson, [N, V]).
 
 %% @private
 get_field(<<1:8, _/binary>>, _, Bin1, _) ->
-  <<?get_float(N), Bin2/binary>> = Bin1,
-  {N, Bin2};
+  case Bin1 of
+    <<?get_float(N), Bin2/binary>> ->
+      {N, Bin2};
+    _ ->
+      <<_:64, Bin2/binary>> = Bin1,
+      {0.0, Bin2}
+      end;
 get_field(<<2:8, _/binary>>, _, Bin1, _) ->
   get_string(Bin1);
 get_field(<<3:8, _/binary>>, _, Bin1, map) ->


### PR DESCRIPTION
when  use mongodb-erlang to execute mongodb command `geoNear` , but when no fields selected it will return 
```
{
        "results" : [ ],
        "stats" : {
                "nscanned" : 0,
                "objectsLoaded" : 0,
                "avgDistance" : NaN,
                "maxDistance" : 0,
                "time" : 0
        },
        "ok" : 1
}
```
in this case  `"avgDistance" : NaN`. its not a float type,  so will  cause the below code badmatch error.
```
get_field(<<1:8, _/binary>>, _, Bin1, _) ->
  <<?get_float(N), Bin2/binary>> = Bin1,
  {N, Bin2};
```
error details is:
```
18:25:25.966 [error] gen_server <0.127.0> terminated with reason: no match of right hand value <<0,0,0,0,0,0,248,255,1,109,97,120,68,105,115,116,97,110,99,101,0,0,0,0,0,0,0,0,0,16,116,105,109,101,0,0,0,0,0>> in bson_binary:get_field/4 line 87
18:25:26.072 [error] CRASH REPORT Process <0.127.0> with 1 neighbours exited with reason: no match of right hand value <<0,0,0,0,0,0,248,255,1,109,97,120,68,105,115,116,97,110,99,101,0,0,0,0,0,0,0,0,0,16,116,105,109,101,0,0,0,0,0>> in bson_binary:get_field/4 line 87 in gen_server:terminate/7 line 826
** exception exit: {badmatch,<<0,0,0,0,0,0,248,255,1,109,97,120,68,105,115,
                               116,97,110,99,101,0,0,0,0,0,0,0,...>>}
     in function  bson_binary:get_field/4 (src/bson_binary.erl, line 87)
     in call from bson_binary:get_field/2 (src/bson_binary.erl, line 151)
     in call from bson_binary:get_fields/2 (src/bson_binary.erl, line 54)
     in call from bson_binary:get_map/1 (src/bson_binary.erl, line 40)
     in call from bson_binary:get_field/2 (src/bson_binary.erl, line 151)
     in call from bson_binary:get_fields/2 (src/bson_binary.erl, line 54)
     in call from bson_binary:get_map/1 (src/bson_binary.erl, line 40)
     in call from mongo_protocol:get_docs/3 (src/core/mongo_protocol.erl, line 115)
```
