### PR TITLE
add uuid subtype 4

### DIFF
--- a/src/bson.erl
+++ b/src/bson.erl
@@ -4,7 +4,7 @@
 
 -export_type([document/0, label/0, value/0]).
 -export_type([arr/0]).
--export_type([bin/0, bfunction/0, uuid/0, md5/0, userdefined/0]).
+-export_type([bin/0, bfunction/0, uuid/0, uuid4/0, md5/0, userdefined/0]).
 -export_type([mongostamp/0, minmaxkey/0]).
 -export_type([utf8/0, regex/0, unixtime/0]).
 -export_type([javascript/0]).
@@ -186,6 +186,7 @@ arr() |
 bin() |
 bfunction() |
 uuid() |
+uuid4() |
 md5() |
 userdefined() |
 objectid() |
@@ -236,6 +237,7 @@ str(CharData) ->
 -type bin() :: {bin, bin, binary()}.
 -type bfunction() :: {bin, function, binary()}.
 -type uuid() :: {bin, uuid, binary()}.
+-type uuid4() :: {bin, uuid4, binary()}.
 -type md5() :: {bin, md5, binary()}.
 -type userdefined() :: {bin, userdefined, binary()}.
 

--- a/src/bson_binary.erl
+++ b/src/bson_binary.erl
@@ -181,18 +181,18 @@ get_values(Bin, Acc, Type) ->
   {_, Value, Bin1} = get_field(Bin, Type),
   get_values(Bin1, [Value | Acc], Type).
 
--type bintype() :: bin | function | uuid | md5 | userdefined.
+-type bintype() :: bin | function | uuid | uuid4 | md5 | userdefined.
 
 %% @private
 -spec put_binary(bintype(), binary()) -> binary().
 put_binary(BinType, Bin) ->
-  Tag = case BinType of bin -> 0; function -> 1; uuid -> 3; md5 -> 5; userdefined -> 128 end,
+  Tag = case BinType of bin -> 0; function -> 1; uuid -> 3; uuid4 -> 4; md5 -> 5; userdefined -> 128 end,
   <<?put_int32(byte_size(Bin)), Tag:8, Bin/binary>>.
 
 %% @private
 -spec get_binary(binary()) -> {bintype(), binary(), binary()}.
 get_binary(<<?get_int32(Size), Tag:8, Bin/binary>>) ->
-  BinType = case Tag of 0 -> bin; 1 -> function; 3 -> uuid; 5 -> md5; 128 -> userdefined end,
+  BinType = case Tag of 0 -> bin; 1 -> function; 3 -> uuid; 4 -> uuid4; 5 -> md5; 128 -> userdefined end,
   <<VBin:Size/binary, Bin1/binary>> = Bin,
   {BinType, VBin, Bin1}.
 

--- a/test/bson_tests.erl
+++ b/test/bson_tests.erl
@@ -57,6 +57,7 @@ binary_test() ->
     <<"eeeeeeeee">>, {bin, bin, VBin},
     <<"f">>, {bin, function, VBin},
     <<"g">>, {bin, uuid, Bin},
+    <<"g4">>, {bin, uuid4, Bin},
     <<"h">>, {bin, md5, VBin},
     <<"i">>, {bin, userdefined, Bin},
     <<"j">>, bson:objectid(bson:unixtime_to_secs(Time), <<2:24/big, 3:16/big>>, 4),


### PR DESCRIPTION
latest mongo versions seem to use subtype 4 uuid as default. without handling it, crashes the mongo driver... e.g. listCollections cmd. 