### PR TITLE
Map with key as list/string not supported

### DIFF
--- a/src/bson_binary.erl
+++ b/src/bson_binary.erl
@@ -45,7 +45,9 @@ get_map(<<?get_int32(N), Bin/binary>>) ->
 put_field_accum(Label, Value, Bin) when is_atom(Label) ->
   <<Bin/binary, (put_field(atom_to_binary(Label, utf8), Value))/binary>>;
 put_field_accum(Label, Value, Bin) when is_binary(Label) ->
-  <<Bin/binary, (put_field(Label, Value))/binary>>.
+  <<Bin/binary, (put_field(Label, Value))/binary>>;
+put_field_accum(Label, Value, Bin) when is_list(Label) ->
+  <<Bin/binary, (put_field(iolist_to_binary(Label), Value))/binary>>.
 
 %% @private
 get_fields(<<>>, Acc) when is_map(Acc) -> Acc;


### PR DESCRIPTION
`
> MapWithMap = #{"map" => true, <<"simple">> => <<"not">>, <<"why">> => #{"because" => <<"with map">>, <<"ok">> => true}},
> bson_binary:put_document(MapWithMap).
`

Would have previously returned an error as it doesn't support keys that are list/strings.