### PR TITLE
Adds map() to put_document spec

### DIFF
--- a/src/bson.app.src
+++ b/src/bson.app.src
@@ -1,7 +1,7 @@
 %% ex: ts=4 sw=4 noexpandtab syntax=erlang
 {application, bson, [
   {description, "BSON are JSON-like objects with a standard binary serialization. See bsonspec.org"},
-  {vsn, "v0.2.2"},
+  {vsn, "v0.2.4"},
   {registered, []},
   {applications, [kernel, stdlib]}
 ]}.

--- a/src/bson_binary.erl
+++ b/src/bson_binary.erl
@@ -21,7 +21,7 @@ get_cstring(Bin) -> % list_to_tuple (binary:split (Bin, <<0>>)).
   <<UBin:Pos/binary, 0:8, Rest/binary>> = Bin,
   {UBin, Rest}.
 
--spec put_document(bson:document()) -> binary().
+-spec put_document(bson:document() | map()) -> binary().
 put_document(Document) ->
   Bin = bson:doc_foldl(fun put_field_accum/3, <<>>, Document),
   <<?put_int32(byte_size(Bin) + 5), Bin/binary, 0:8>>.


### PR DESCRIPTION
### Description

There patch contains a fix for a bug in bson-erlang that prevents dialyzer from recognizing `map()` as a valid input type to `bson_binary:put_document`.