### PR TITLE
Remove unused lines to fix dialyzer

### DIFF
--- a/src/bson.erl
+++ b/src/bson.erl
@@ -309,10 +309,6 @@ flatten(Key, Value, Acc) ->
 
 %% @private
 append_dot(<<>>) -> <<>>;
-append_dot(Key) when is_atom(Key) -> append_dot(atom_to_binary(Key, utf8));
-append_dot(Key) when is_integer(Key) -> append_dot(integer_to_binary(Key));
-append_dot(Key) when is_float(Key) -> append_dot(float_to_binary(Key));
-append_dot(Key) when is_list(Key) -> append_dot(list_to_binary(Key));
 append_dot(Key) -> <<Key/binary, <<".">>/binary>>.
 
 %% @private


### PR DESCRIPTION
Fixes the following dialyzer errors:

```
bson-erlang % rebar3 dialyzer
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling bson
===> Dialyzer starting, this may take a while...
===> Add debug_info to compiler options (erl_opts) if Dialyzer fails to load Core Erlang.
===> Updating plt...
===> Resolving files...
===> Checking 202 files in _build/default/rebar3_23.3.4.1_plt...
===> Doing success typing analysis...
===> Resolving files...
===> Analyzing 3 files with _build/default/rebar3_23.3.4.1_plt...

src/bson.erl
Line 312: Guard test is_atom(Key::bitstring()) can never succeed
Line 313: Guard test is_integer(Key::bitstring()) can never succeed
Line 314: Guard test is_float(Key::bitstring()) can never succeed
Line 315: Guard test is_list(Key::bitstring()) can never succeed
===> Warnings written to _build/default/23.3.4.1.dialyzer_warnings
===> Warnings occurred running dialyzer: 4
```